### PR TITLE
fix command order at README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,8 @@ The server was tested with Python 3.9 and 3.10.
 Use [git](https://git-scm.com) to download the Unciv_server
 
 ```bash
-mkdir Unciv_server
-cd Unciv_server
 git clone https://github.com/Mape6/Unciv_server.git
+cd Unciv_server
 ```
 
 ## Usage


### PR DESCRIPTION
`git clone` already creates `Unciv_server` folder automatically. So, `mkdir` is not necessary. Also `cd` should be used after `git clone`.